### PR TITLE
Fix HTML validation errors

### DIFF
--- a/layouts/partials/helpers/debug-tables/debug-helpers/content-details.html
+++ b/layouts/partials/helpers/debug-tables/debug-helpers/content-details.html
@@ -3,14 +3,14 @@
 <details class="details-debug-hugo debug-content-hugo">
     <summary class="summary-debug-hugo">{{ if $content }}{{ len $content }}{{ else }}0{{end}} characters</summary>
 {{- with $content -}}
-    <code class="code-debug-hugo">
-        {{- if $preformatted }}
-        <pre class="pre-debug-hugo">
-        {{- end }}
-        {{- . | htmlEscape | htmlUnescape -}}
-        {{- if $preformatted }}
-        </pre>
-        {{- end }}
-    </code>
+{{- if $preformatted }}
+    <pre class="pre-debug-hugo">
+    {{- end }}
+        <code class="code-debug-hugo">
+        {{- . | htmlEscape | safeHTML -}}
+        </code>
+    {{- if $preformatted }}
+    </pre>
+{{- end }}
 {{- end }}
 </details>

--- a/layouts/partials/helpers/debug-tables/debug-helpers/expand-item.html
+++ b/layouts/partials/helpers/debug-tables/debug-helpers/expand-item.html
@@ -2,20 +2,20 @@
 {{- if reflect.IsSlice $curCtx }}
     <details class="details-debug-hugo">
         <summary class="summary-debug-hugo">{{- len $curCtx -}}</summary>
-        <ul class="list-debug-hugo">
+        <div class="list-debug-hugo">
             {{- range $curCtx }}
                 {{- partial "helpers/debug-tables/debug-helpers/expand-var" (dict "value" .) }}
             {{- end }}
-        </ul>
+        </div>
     </details>
 {{- else if reflect.IsMap $curCtx }}
     <details class="details-debug-hugo">
         <summary class="summary-debug-hugo">{{- len $curCtx -}}</summary>
-        <ul class="list-debug-hugo">
+        <div class="list-debug-hugo">
             {{- range $key, $value := $curCtx }}
                 {{- partial "helpers/debug-tables/debug-helpers/expand-var" (dict "key" $key "value" $value) }}
             {{- end }}
-        </ul>
+        </div>
     </details>
 {{- else -}}
     {{- partial "helpers/debug-tables/debug-helpers/expand-var" (dict "value" $curCtx) }}

--- a/layouts/partials/helpers/debug-tables/debug-helpers/expand-var.html
+++ b/layouts/partials/helpers/debug-tables/debug-helpers/expand-var.html
@@ -5,23 +5,23 @@
     {{- if reflect.IsMap $value }}
         <details class="details-debug-hugo">
             <summary class="summary-debug-hugo">{{- $key }}: {{ len $value -}}</summary>
-            <ul class="list-debug-hugo">
+            <div class="list-debug-hugo">
                 {{- range $key2, $value2 := $value -}}
                     {{- partial "helpers/debug-tables/debug-helpers/expand-var" (dict "key" $key2 "value" $value2) }}
                 {{- end }}
-            </ul>
+            </div>
             </details>
     {{- else if reflect.IsSlice $value }}
         <details class="details-debug-hugo">
             <summary class="summary-debug-hugo">{{- $key }}: {{ len $value -}}</summary>
-                <ul class="list-debug-hugo">
+                <div class="list-debug-hugo">
                     {{- range $value -}}
                         {{- partial "helpers/debug-tables/debug-helpers/expand-item" . -}}
                     {{- end }}
-                </ul>
+                </div>
         </details>
     {{ else -}}
-            <li class="list-item-debug-hugo">{{ $key }}: {{ $value }}</li>
+            <div class="list-item-debug-hugo">{{ $key }}: {{ $value }}</div>
     {{- end -}}
 {{- else -}}
     {{- if reflect.IsSlice $value -}}
@@ -33,9 +33,9 @@
         </details>
     {{- else -}}
         {{- if $key }}
-            <li class="list-item-debug-hugo">{{ $key }}: {{ $value }}</li>
+            <div class="list-item-debug-hugo">{{ $key }}: {{ $value }}</div>
         {{- else }}
-            <li class="list-item-debug-hugo">{{ $value }}</li>
+            <div class="list-item-debug-hugo">{{ $value }}</div>
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/layouts/partials/helpers/debug-tables/debug-helpers/return-page-details.html
+++ b/layouts/partials/helpers/debug-tables/debug-helpers/return-page-details.html
@@ -10,8 +10,8 @@
     {{- partial "helpers/debug-tables/tables/page" (dict "Page" . "basePage" $basePage "Site" $curSite "baseSite" $baseSite "expandPage" $expandPage) }}
     </details>
     {{- else }}
-    <li class="details-debug-hugo">
+    <div class="details-debug-hugo">
         <span class="summary-debug-hugo {{if eq . $basePage }}debug-current-hugo{{ end }}">{{ partial "helpers/debug-tables/debug-helpers/return-page-title" . -}}</span>
-    </li>
+    </div>
     {{- end }}
 {{- end }}

--- a/layouts/partials/helpers/debug-tables/debug-helpers/site-details.html
+++ b/layouts/partials/helpers/debug-tables/debug-helpers/site-details.html
@@ -10,8 +10,8 @@
     {{ partial "helpers/debug-tables/tables/site" (dict "Site" .Site "baseSite" $baseSite "Page" $curPage "basePage" $basePage "expandPage" $expandPage) }}
 </details>
 {{ else }}
-<li class="details-debug-hugo debug-current-hugo">
+<div class="details-debug-hugo debug-current-hugo">
     <span class="summary-debug-hugo">{{ if .Site.Title }}{{ .Site.Title }}{{ else }}Untitled Site{{ end }}</span>
-</li>
+</div>
 {{ end }}
 {{- end -}}

--- a/layouts/partials/helpers/debug-tables/debug-helpers/sites-details.html
+++ b/layouts/partials/helpers/debug-tables/debug-helpers/sites-details.html
@@ -8,13 +8,13 @@
 <details class="details-debug-hugo debug-sites-hugo">
     <summary class="summary-debug-hugo">{{ len $sites }}</summary>
     {{ with $sites }}
-      <ul class="list-debug-hugo debug-sites-hugo">
+      <div class="list-debug-hugo debug-sites-hugo">
         {{ range . }}
           {{ partial "helpers/debug-tables/debug-helpers/site-details" (dict
             "Page" $curPage "basePage" $basePage "Site" . "baseSite" $baseSite "expandPage" $expandPage
         ) }}
         {{ end }}
-      </ul>
+      </div>
     {{ end }}
 </details>
 {{- end -}}

--- a/layouts/partials/helpers/debug-tables/debug-page-list.html
+++ b/layouts/partials/helpers/debug-tables/debug-page-list.html
@@ -3,8 +3,8 @@
 {{- $basePage := .basePage -}}
 {{- $baseSite := .baseSite -}}
 {{- $expandPage := .expandPage -}}
-<ul class="list-debug-hugo debug-pages-hugo">
+<div class="list-debug-hugo debug-pages-hugo">
     {{- range .Pages -}}
         {{- partial "helpers/debug-tables/debug-helpers/return-page-details" (dict "Page" . "basePage" $basePage "Site" $curSite "baseSite" $baseSite "expandPage" $expandPage ) -}}
     {{- end -}}
-</ul>
+</div>

--- a/layouts/partials/helpers/debug-tables/debug-tables-list.html
+++ b/layouts/partials/helpers/debug-tables/debug-tables-list.html
@@ -15,7 +15,7 @@
 <section class="section-debug-hugo debug-variables-hugo" aria-label="Hugo Debug Section">
     <details class="details-debug-hugo">
         <summary class="summary-debug-hugo">Hugo Debug Table</summary>
-        <ul class="list-debug-hugo debug-tables">
+        <div class="list-debug-hugo debug-tables">
 {{- $tablesToShow := (slice "page") -}}
 {{- $tablesToShow = $tablesToShow | append "section" -}}
 {{- $tablesToShow = $tablesToShow | append "file" -}}
@@ -40,7 +40,7 @@
                     <p class="list-item-debug-hugo"><i>Current version from <a href="https://github.com/danielfdickinson/hugoDebugTables">github.com/danielfdickinson/hugoDebugTables</a></i></p>
                 </div>
             </details>
-        </ul>
+        </div>
     </details>
 </section>
 {{ end }}

--- a/layouts/partials/helpers/debug-tables/tables/menus.html
+++ b/layouts/partials/helpers/debug-tables/tables/menus.html
@@ -3,14 +3,14 @@
     <details class="details-debug-hugo">
         <summary class="summary-debug-hugo">{{- printf "%s: %d" $key (len $value) -}}</summary>
     {{- if gt (len $value) 0 -}}
-        <ul class="list-debug-hugo debug-menus-hugo">
+        <div class="list-debug-hugo debug-menus-hugo">
         {{- range $value }}
             <details class="details-debug-hugo">
             <summary>{{- .Identifier -}}</summary>
             {{- partial "helpers/debug-tables/tables/menu" . -}}
             </details>
         {{- end }}
-        </ul>
+        </div>
     {{- end -}}
     </details>
 {{- end }}

--- a/layouts/partials/helpers/debug-tables/tables/page.html
+++ b/layouts/partials/helpers/debug-tables/tables/page.html
@@ -51,7 +51,7 @@
         "Page" $curPage "basePage" $basePage "Site" .Sites.First "baseSite" $baseSite "expandPage" $expandPage))
         ".Summary" (partial "helpers/debug-tables/debug-helpers/content-details"  (dict "Content" .Summary "pre" false))
         ".TableOfContents" (partial "helpers/debug-tables/debug-helpers/content-details"  (dict "Content" .TableOfContents "pre" true))
-        ".Title" (.Title | htmlEscape | htmlUnescape)
+        ".Title" (.Title | htmlEscape | safeHTML)
         ".Translations" (partial "helpers/debug-tables/debug-page-list" (
             dict "Pages" .Translations "Page" $curPage "basePage" $basePage "Site" $curSite "baseSite" $baseSite "expandPage" $expandPage))
         ".TranslationKey" .TranslationKey

--- a/layouts/partials/helpers/debug-tables/tables/page.html
+++ b/layouts/partials/helpers/debug-tables/tables/page.html
@@ -9,7 +9,7 @@
         ".Aliases" (partial "helpers/debug-tables/debug-helpers/expand-item" .Aliases)
         ".Content"  (partial "helpers/debug-tables/debug-helpers/content-details" (dict "Content" .Content "pre" true))
         ".Date" ( .Date.Local)
-        ".Description" (.Description | htmlEscape | htmlUnescape)
+        ".Description" (.Description | htmlEscape | safeHTML)
         ".Draft" .Draft
         ".ExpiryDate" .ExpiryDate.Local
         ".FuzzyWordCount" .FuzzyWordCount


### PR DESCRIPTION
There were a issues with using details inside an UL element, as well as use of PRE inside CODE instead of the other way around. Also HTML as text was not properly escaped and then shown.